### PR TITLE
get flut to compile with gcc + get ctest working

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,26 @@ find_path(FLUT_INCLUDE_DIR
 	PATHS ${CMAKE_SOURCE_DIR}
 	)
 
+# Compiler flags.
+# ---------------
+# Must compile with C++11 with gcc/clang.
+if(${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU" OR
+   ${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang")
+    if(APPLE)
+        if(XCODE)
+            set(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LANGUAGE_STANDARD "c++11")
+            set(CMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LIBRARY "libc++")
+        else()
+            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+            if(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
+                set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
+            endif()
+        endif()
+    else()
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+    endif()
+endif()
+	
 # Place build products (libraries, executables) in root
 # binary (build) directory. Otherwise, they get scattered around
 # the build directory and so the dll's aren't next to the executables.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,4 +47,4 @@ if(MSVC)
 endif()
 
 enable_testing()
-add_test(flut_test "${CMAKE_SOURCE_DIR}/bin/${CONFIG_NAME}/test.exe")
+add_test(flut_test "${CMAKE_SOURCE_DIR}/bin/${CONFIG_NAME}/flut_test")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,8 +7,9 @@ project(flut)
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 find_path(FLUT_INCLUDE_DIR
-    NAMES "flut/types.h"
-    )
+    NAMES flut/system/types.hpp
+	PATHS ${CMAKE_SOURCE_DIR}
+	)
 
 # Place build products (libraries, executables) in root
 # binary (build) directory. Otherwise, they get scattered around

--- a/test/scone/Quat.h
+++ b/test/scone/Quat.h
@@ -4,6 +4,8 @@
 #include "math.h"
 #include "Vec3.h"
 
+#include <cstring> // needed for gcc
+
 namespace scone
 {
 	enum EulerOrder

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -21,7 +21,5 @@ int main( int argc, char* argv[] )
 	pn.add( "test", 1.2 );
 	auto a = pn.get< float >();
 
-	flut::wait_for_key();
-
 	return 0;
 }


### PR DESCRIPTION
some cmake fixes and add a #include to get flut to compile with gcc. mainly had issues on both windows and unix with the find_path() function, which doesn't seem to search the source directory unless explicitly instructed to do so.
