### PR TITLE
fix string constructor in char_stream.cpp

### DIFF
--- a/flut/char_stream.cpp
+++ b/flut/char_stream.cpp
@@ -80,7 +80,7 @@ namespace flut
 					break;
 				}
 			}
-			string s = string( cur_pos, end_pos );
+		    string s = string( cur_pos, size_t( end_pos - cur_pos ) );
 			process_end_pos();
 			return s;
 		}


### PR DESCRIPTION
@tgeijten PR fixes a misuse of the string constructor, causing compiler errors in gcc. One question though, should this be `size_t( end_pos - cur_pos )` or `size_t( end_pos - cur_pos + 1)`?
