### PR TITLE
gcc compile fixes

### DIFF
--- a/flut/flag_set.hpp
+++ b/flut/flag_set.hpp
@@ -10,7 +10,7 @@ namespace flut
 	{
 		flag_set() : data( StorageT( 0 ) ) {}
 		flag_set( const flag_set& o ) : data( o.data ) {}
-		flag_set( std::initializer_list< EnumT >& flags ) : data( StorageT( 0 ) ) { for ( f : flags ) set( f ); }
+		flag_set( std::initializer_list< EnumT >& flags ) : data( StorageT( 0 ) ) { for ( auto f : flags ) set( f ); }
 
 		flag_set& operator=( const flag_set& o ) { data = o.data; return *this; }
 		flag_set& operator|=( const flag_set& o ) { data |= o.data; return *this; }

--- a/flut/system/log.hpp
+++ b/flut/system/log.hpp
@@ -46,7 +46,12 @@ namespace flut
 		{ str << var; log_output( l, str, args... ); }
 
 		template< typename... Args > void message( level l, const Args&... args )
-		{ if ( get_level() <= l ) log_output( l, std::stringstream(), args... ); }
+		{ 
+            if ( get_level() <= l ) {
+                std::stringstream str;
+                log_output( l, str, args... );
+            } 
+        }
 
 		template< typename... Args > void trace( const Args&... args ) {
 #if ( FLUT_STATIC_LOG_LEVEL <= FLUT_LOG_LEVEL_TRACE )

--- a/flut/system/version.hpp
+++ b/flut/system/version.hpp
@@ -9,25 +9,25 @@ namespace flut
 	{
 	public:
 		version( int major, int minor, int maintenance, int build = 0, string postfix = "" ) :
-			major( major ), minor( minor ), maintenance( maintenance ), build( build ), postfix( postfix ) {}
+			majorVer( major ), minorVer( minor ), maintenance( maintenance ), build( build ), postfix( postfix ) {}
 
 		version( const string& version ) {
 			std::stringstream str( version );
 			char dummy;
-			str >> major >> dummy >> minor >> dummy >> maintenance >> dummy;
+			str >> majorVer >> dummy >> minorVer >> dummy >> maintenance >> dummy;
 			if ( str.good() ) str >> build;
 			if ( str.good() ) str >> postfix;
 		}
 
 		string to_str() const {
-			string s = stringf( "%d.%d.%d", major, minor, maintenance );
+			string s = stringf( "%d.%d.%d", majorVer, minorVer, maintenance );
 			if ( build > 0 ) s += stringf( ".%d", build );
 			if ( !postfix.empty() ) s += ' ' + postfix;
 			return s;
 		}
 
-		int major;
-		int minor;
+		int majorVer;
+		int minorVer;
 		int maintenance;
 		int build;
 


### PR DESCRIPTION
Few fixes to get it to compile on gcc 4.8.1. 

Wanted to make a note on change to `log.hpp`. Needed to change on GCC because it could not convert `std::stringstream` to `std::stringstream&`. I made this change to keep the behavior the same, though it seems like since it is temporary, things will be lost once it's in the `stringstream`?