### PR TITLE
fix rapidxml to compile with gcc

### DIFF
--- a/contrib/rapidxml-1.13/rapidxml_print.hpp
+++ b/contrib/rapidxml-1.13/rapidxml_print.hpp
@@ -101,7 +101,15 @@ namespace rapidxml
 
         ///////////////////////////////////////////////////////////////////////////
         // Internal printing operations
-    
+        template<class OutIt, class Ch> inline OutIt print_cdata_node(OutIt out, const xml_node<Ch> *node, int flags, int indent);
+        template<class OutIt, class Ch> inline OutIt print_children(OutIt out, const xml_node<Ch> *node, int flags, int indent);
+        template<class OutIt, class Ch> inline OutIt print_comment_node(OutIt out, const xml_node<Ch> *node, int flags, int indent);
+        template<class OutIt, class Ch> inline OutIt print_data_node(OutIt out, const xml_node<Ch> *node, int flags, int indent);
+        template<class OutIt, class Ch> inline OutIt print_declaration_node(OutIt out, const xml_node<Ch> *node, int flags, int indent);
+        template<class OutIt, class Ch> inline OutIt print_doctype_node(OutIt out, const xml_node<Ch> *node, int flags, int indent);
+        template<class OutIt, class Ch> inline OutIt print_element_node(OutIt out, const xml_node<Ch> *node, int flags, int indent);
+        template<class OutIt, class Ch> inline OutIt print_pi_node(OutIt out, const xml_node<Ch> *node, int flags, int indent);    
+
         // Print node
         template<class OutIt, class Ch>
         inline OutIt print_node(OutIt out, const xml_node<Ch> *node, int flags, int indent)

--- a/contrib/rapidxml-1.13/rapidxml_print.hpp
+++ b/contrib/rapidxml-1.13/rapidxml_print.hpp
@@ -101,14 +101,6 @@ namespace rapidxml
 
         ///////////////////////////////////////////////////////////////////////////
         // Internal printing operations
-        template<class OutIt, class Ch> inline OutIt print_cdata_node(OutIt out, const xml_node<Ch> *node, int flags, int indent);
-        template<class OutIt, class Ch> inline OutIt print_children(OutIt out, const xml_node<Ch> *node, int flags, int indent);
-        template<class OutIt, class Ch> inline OutIt print_comment_node(OutIt out, const xml_node<Ch> *node, int flags, int indent);
-        template<class OutIt, class Ch> inline OutIt print_data_node(OutIt out, const xml_node<Ch> *node, int flags, int indent);
-        template<class OutIt, class Ch> inline OutIt print_declaration_node(OutIt out, const xml_node<Ch> *node, int flags, int indent);
-        template<class OutIt, class Ch> inline OutIt print_doctype_node(OutIt out, const xml_node<Ch> *node, int flags, int indent);
-        template<class OutIt, class Ch> inline OutIt print_element_node(OutIt out, const xml_node<Ch> *node, int flags, int indent);
-        template<class OutIt, class Ch> inline OutIt print_pi_node(OutIt out, const xml_node<Ch> *node, int flags, int indent);    
 
         // Print node
         template<class OutIt, class Ch>

--- a/contrib/rapidxml-1.13/rapidxml_print.hpp
+++ b/contrib/rapidxml-1.13/rapidxml_print.hpp
@@ -101,7 +101,7 @@ namespace rapidxml
 
         ///////////////////////////////////////////////////////////////////////////
         // Internal printing operations
-
+    
         // Print node
         template<class OutIt, class Ch>
         inline OutIt print_node(OutIt out, const xml_node<Ch> *node, int flags, int indent)

--- a/flut/buffer/storage.hpp
+++ b/flut/buffer/storage.hpp
@@ -23,7 +23,7 @@ namespace flut
 		const L& get_label( index_t channel ) const { return labels_[ channel ]; }
 
 		/// find index of a label
-		index_t find_channel( const L& label ) const { auto it = label_indices_.find( label ); return ( it != label_indices_.end() ) ? it->second : no_index; }
+		index_t find_channel( const L& label ) const { auto it = labels_.find( label ); return ( it != labels_.end() ) ? it->second : no_index; }
 
 		/// add frame to storage
 		void add_frame( T value = T( 0 ) ) { data_.resize( data_.size() + channel_size(), value ); ++frame_size_; }

--- a/flut/buffer/storage.hpp
+++ b/flut/buffer/storage.hpp
@@ -98,7 +98,7 @@ namespace flut
 	private:
 		size_t frame_size_;
 		std::vector< L > labels_;
-        std::vector< T > data_;
+		std::vector< T > data_;
 	};
 
 	template< typename T, typename L > std::ostream& operator<<( std::ostream& str, const storage< T, L >& buf )

--- a/flut/math/quat.hpp
+++ b/flut/math/quat.hpp
@@ -124,7 +124,7 @@ namespace flut
 		template< typename T > radian_< T > roll( const quat_<T>& q )
 		{
 			T ty = T(2) * q.y, tz = T(2) * q.z;
-			T twz = tz * q.w, Real txy = ty * q.x, tyy = ty * q.y, tzz = tz * q.z;
+			T twz = tz * q.w, txy = ty * q.x, tyy = ty * q.y, tzz = tz * q.z;
 			return radian_< T >( atan2( txy + twz, T(1) - ( tyy + tzz ) ) );
 		}
 
@@ -172,7 +172,7 @@ namespace flut
 		{
 			flut_assert( is_normalized( q ) );
 			T l = sqrt( q.x * q.x + q.y * q.y + q.z * q.z );
-			if ( l > constants::epsilon() )
+			if ( l > constants<T>::epsilon() )
 			{
 				T s = T(1) / l;
 				return std::pair< vec3_<T>, radian_<T> >{ vec3f( s * q.x, s * q.y, s * q.z ), radian_<T>( T(2) * std::acos( q.w ) ) };

--- a/flut/prop_node.hpp
+++ b/flut/prop_node.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "string_tools.hpp"
 #include "flut/system/platform.hpp"
 #include "flut/system/types.hpp"
 #include "flut/system/assert.hpp"

--- a/flut/prop_node.hpp
+++ b/flut/prop_node.hpp
@@ -19,7 +19,7 @@ namespace flut
 	/// make a prop_node with a value
 	template< typename T > prop_node make_prop_node( const T& value );
 
-    /// forward declare prop_node_cast
+	/// forward declare prop_node_cast
 	template< typename T, typename E = void > struct prop_node_cast;
 
 	/// prop_node class
@@ -179,7 +179,7 @@ namespace flut
 		container_t children;
 	};
 
-    /// prop_node_cast and specializations
+	/// prop_node_cast and specializations
 	template<> struct prop_node_cast< prop_node > {
 		static prop_node from( const prop_node& pn ) { return pn; }
 		static prop_node to( const prop_node& value ) { return value; }

--- a/flut/prop_node_tools.cpp
+++ b/flut/prop_node_tools.cpp
@@ -8,16 +8,16 @@
 
 // Forward declearations for rapidxml
 namespace rapidxml {
-    namespace internal {
-        template<class OutIt, class Ch> inline OutIt print_cdata_node(OutIt out, const xml_node<Ch> *node, int flags, int indent);
-        template<class OutIt, class Ch> inline OutIt print_children(OutIt out, const xml_node<Ch> *node, int flags, int indent);
-        template<class OutIt, class Ch> inline OutIt print_comment_node(OutIt out, const xml_node<Ch> *node, int flags, int indent);
-        template<class OutIt, class Ch> inline OutIt print_data_node(OutIt out, const xml_node<Ch> *node, int flags, int indent);
-        template<class OutIt, class Ch> inline OutIt print_declaration_node(OutIt out, const xml_node<Ch> *node, int flags, int indent);
-        template<class OutIt, class Ch> inline OutIt print_doctype_node(OutIt out, const xml_node<Ch> *node, int flags, int indent);
-        template<class OutIt, class Ch> inline OutIt print_element_node(OutIt out, const xml_node<Ch> *node, int flags, int indent);
-        template<class OutIt, class Ch> inline OutIt print_pi_node(OutIt out, const xml_node<Ch> *node, int flags, int indent);
-    }
+	namespace internal {
+		template<class OutIt, class Ch> inline OutIt print_cdata_node(OutIt out, const xml_node<Ch> *node, int flags, int indent);
+		template<class OutIt, class Ch> inline OutIt print_children(OutIt out, const xml_node<Ch> *node, int flags, int indent);
+		template<class OutIt, class Ch> inline OutIt print_comment_node(OutIt out, const xml_node<Ch> *node, int flags, int indent);
+		template<class OutIt, class Ch> inline OutIt print_data_node(OutIt out, const xml_node<Ch> *node, int flags, int indent);
+		template<class OutIt, class Ch> inline OutIt print_declaration_node(OutIt out, const xml_node<Ch> *node, int flags, int indent);
+		template<class OutIt, class Ch> inline OutIt print_doctype_node(OutIt out, const xml_node<Ch> *node, int flags, int indent);
+		template<class OutIt, class Ch> inline OutIt print_element_node(OutIt out, const xml_node<Ch> *node, int flags, int indent);
+		template<class OutIt, class Ch> inline OutIt print_pi_node(OutIt out, const xml_node<Ch> *node, int flags, int indent);
+	}
 }
 #include <contrib/rapidxml-1.13/rapidxml_print.hpp>
 

--- a/flut/prop_node_tools.cpp
+++ b/flut/prop_node_tools.cpp
@@ -1,10 +1,25 @@
 #include "prop_node_tools.hpp"
-
-#include <contrib/rapidxml-1.13/rapidxml.hpp>
-#include <contrib/rapidxml-1.13/rapidxml_print.hpp>
 #include <fstream>
 #include "system/path.hpp"
 #include "string_tools.hpp"
+
+// Include rapidxml.hpp first for xml_node
+#include <contrib/rapidxml-1.13/rapidxml.hpp>
+
+// Forward declearations for rapidxml
+namespace rapidxml {
+    namespace internal {
+        template<class OutIt, class Ch> inline OutIt print_cdata_node(OutIt out, const xml_node<Ch> *node, int flags, int indent);
+        template<class OutIt, class Ch> inline OutIt print_children(OutIt out, const xml_node<Ch> *node, int flags, int indent);
+        template<class OutIt, class Ch> inline OutIt print_comment_node(OutIt out, const xml_node<Ch> *node, int flags, int indent);
+        template<class OutIt, class Ch> inline OutIt print_data_node(OutIt out, const xml_node<Ch> *node, int flags, int indent);
+        template<class OutIt, class Ch> inline OutIt print_declaration_node(OutIt out, const xml_node<Ch> *node, int flags, int indent);
+        template<class OutIt, class Ch> inline OutIt print_doctype_node(OutIt out, const xml_node<Ch> *node, int flags, int indent);
+        template<class OutIt, class Ch> inline OutIt print_element_node(OutIt out, const xml_node<Ch> *node, int flags, int indent);
+        template<class OutIt, class Ch> inline OutIt print_pi_node(OutIt out, const xml_node<Ch> *node, int flags, int indent);
+    }
+}
+#include <contrib/rapidxml-1.13/rapidxml_print.hpp>
 
 namespace flut
 {


### PR DESCRIPTION
This PR adds forward declarations necessary for GCC 4.7 and above. Also adds a missing #include. @tgeijten 